### PR TITLE
Add GraalVM native build profile and documentation

### DIFF
--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -1,0 +1,15 @@
+FROM debian:bookworm-slim AS runtime
+
+ENV APP_HOME=/app
+WORKDIR ${APP_HOME}
+
+RUN useradd --system --home ${APP_HOME} --shell /usr/sbin/nologin spring
+
+COPY target/translate ${APP_HOME}/translate
+RUN chown spring:spring ${APP_HOME}/translate \
+    && chmod +x ${APP_HOME}/translate
+
+EXPOSE 8080
+USER spring
+
+ENTRYPOINT ["/app/translate"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# API Translate
+
+REST API construída com Spring Boot 3 que integra com o AWS Bedrock Runtime para realizar traduções. Este documento explica co
+mo gerar uma build nativa com GraalVM e como empacotar o binário em uma imagem Docker minimalista.
+
+## Pré-requisitos
+
+- JDK 21 (por exemplo, a distribuição GraalVM ou Liberica Native Image Kit) disponível em `JAVA_HOME`.
+- Ferramentas nativas (GNU build tools) configuradas conforme a documentação do GraalVM para seu sistema operacional.
+- Docker instalado caso deseje gerar a imagem containerizada.
+
+## Executando em modo JVM
+
+```bash
+./mvnw spring-boot:run
+```
+
+## Gerando uma imagem nativa com GraalVM
+
+1. Garanta que está usando um JDK compatível com native-image (GraalVM ou distribuição equivalente).
+2. Execute o build nativo:
+
+   ```bash
+   ./mvnw -Pnative -DskipTests native:compile
+   ```
+
+   O binário será gerado em `target/translate`.
+
+3. Rode o executável diretamente:
+
+   ```bash
+   ./target/translate
+   ```
+
+   O servidor será iniciado na porta `8080` por padrão.
+
+## Construindo uma imagem Docker com o binário nativo
+
+Após gerar o binário nativo (passo anterior), utilize o `Dockerfile.native` incluso no projeto:
+
+```bash
+docker build -f Dockerfile.native -t translate-native .
+```
+
+Para executar o container:
+
+```bash
+docker run --rm -p 8080:8080 translate-native
+```
+
+Isso iniciará o binário nativo dentro de uma imagem Debian slim com um usuário não privilegiado.
+

--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,12 @@
 		<tag/>
 		<url/>
 	</scm>
-	<properties>
-		<java.version>21</java.version>
-		<aws.java.sdk.version>2.29.15</aws.java.sdk.version>
-	</properties>
+        <properties>
+                <java.version>21</java.version>
+                <aws.java.sdk.version>2.29.15</aws.java.sdk.version>
+                <native.buildtools.version>0.10.3</native.buildtools.version>
+                <native.build.skip>true</native.build.skip>
+        </properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -76,13 +78,40 @@
 		</dependency>
 	</dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+        <build>
+                <plugins>
+                        <plugin>
+                                <groupId>org.springframework.boot</groupId>
+                                <artifactId>spring-boot-maven-plugin</artifactId>
+                        </plugin>
+                        <plugin>
+                                <groupId>org.graalvm.buildtools</groupId>
+                                <artifactId>native-maven-plugin</artifactId>
+                                <version>${native.buildtools.version}</version>
+                                <extensions>true</extensions>
+                                <configuration>
+                                        <skip>${native.build.skip}</skip>
+                                </configuration>
+                                <executions>
+                                        <execution>
+                                                <id>build-native</id>
+                                                <phase>package</phase>
+                                                <goals>
+                                                        <goal>compile-no-fork</goal>
+                                                </goals>
+                                        </execution>
+                                </executions>
+                        </plugin>
+                </plugins>
+        </build>
+
+        <profiles>
+                <profile>
+                        <id>native</id>
+                        <properties>
+                                <native.build.skip>false</native.build.skip>
+                        </properties>
+                </profile>
+        </profiles>
 
 </project>


### PR DESCRIPTION
## Summary
- enable GraalVM native-image compilation through the GraalVM build tools Maven plugin and a dedicated `native` profile
- document how to generate and run the native executable, including container image build instructions
- add a Dockerfile that runs the pre-built native binary in a slim Debian runtime

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68d86a9c14608322814647c354fc032a